### PR TITLE
Changed $SASL_PASSWD to $SASL_PASSWORD

### DIFF
--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -209,15 +209,15 @@ else
   echo "'/tmp/postfix/main.cf' not provided. No extra postfix settings loaded."
 fi
 
-if [ ! -z "$SASL_PASSWD" ]; then
-  echo "$SASL_PASSWD" > /etc/postfix/sasl_passwd
+if [ ! -z "$SASL_PASSWORD" ]; then
+  echo "$SASL_PASSWORD" > /etc/postfix/sasl_passwd
   postmap hash:/etc/postfix/sasl_passwd
   rm /etc/postfix/sasl_passwd
   chown root:root /etc/postfix/sasl_passwd.db
   chmod 0600 /etc/postfix/sasl_passwd.db
   echo "Loaded SASL_PASSWORD"
 else
-  echo "==> Warning: 'SASL_PASSWORD' is not provided. /etc/postfix/sasl_passwd not created."
+  echo "Info: SASL_PASSWORD is not provided. /etc/postfix/sasl_passwd not created."
 fi
 
 echo "Fixing permissions"


### PR DESCRIPTION
The README lists the environmental variable as `SASL_PASSWORD` while the startup script was actually looking for `SASL_PASSWD`. The script now looks for `SASL_PASSWORD` which is consistent with documentation.

Also changed warning to info, as per discussion in #120